### PR TITLE
GET /method endpoint for method calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,14 @@
     "type": "git",
     "url": "github.com/ropelive/rest"
   },
-  "keywords": ["rope", "rpc", "rest", "api", "kite", "microservice"],
+  "keywords": [
+    "rope",
+    "rpc",
+    "rest",
+    "api",
+    "kite",
+    "microservice"
+  ],
   "author": "Gokmen Goksel",
   "license": "MIT"
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
+export const ROPE_SERVER = process.env.ROPE_SERVER || 'http://0.0.0.0:3210'
 export const REST_PORT = process.env.REST_PORT || 3435
 export const REST_TIMEOUT = process.env.REST_TIMEOUT || 10000
 export const STATE = {

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,27 @@ app.get('/query/:method?', (req, res) => {
     )
 })
 
+app.get('/method/:kiteId?/:method', (req, res) => {
+  const { kiteId, method } = req.params
+  let args = req.query.args
+
+  if (!Array.isArray(args)) {
+    args = [args]
+  }
+
+  args = args.map(arg => {
+    try {
+      return JSON.parse(arg)
+    } catch (err) {
+      return arg
+    }
+  })
+
+  if (args.length == 1) args = args[0]
+
+  run(kiteId, method, args, res)
+})
+
 app.post(
   '/:kiteId?/:method',
   jsonParser,

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,9 @@ import express from 'express'
 import bodyParser from 'body-parser'
 
 import { Rope } from '@rope/node'
-import { REST_PORT, REST_TIMEOUT, STATE } from './constants'
+import { ROPE_SERVER, REST_PORT, REST_TIMEOUT, STATE } from './constants'
 
-const rope = new Rope('rope-rest')
+const rope = new Rope('rope-rest', {}, { url: ROPE_SERVER })
 
 const app = express()
 const jsonParser = bodyParser.json()

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,10 @@ const jsonParser = bodyParser.json()
 
 function run(kiteId, method, args, res) {
   if (rope.readyState != 1) {
-    return res.status(500).send('REST IS NOT READY')
+    return res
+      .status(500)
+      .type('txt')
+      .send('REST IS NOT READY')
   }
 
   rope
@@ -22,16 +25,24 @@ function run(kiteId, method, args, res) {
       let message = err.message || 'An unknown error occurred'
       if (err.name == 'TimeoutError')
         message = `Couldn't get response in ${REST_TIMEOUT}ms`
-      res.status(408).send(message)
+      res
+        .status(408)
+        .type('txt')
+        .send(message)
     })
 }
 
-app.get('/', (req, res) => res.send(`ROPE REST ${STATE[rope.readyState]}`))
+app.get('/', (req, res) =>
+  res.type('txt').send(`ROPE REST ${STATE[rope.readyState]}`)
+)
 
 app.get('/query/:method?', (req, res) => {
   const { method } = req.params
   if (rope.readyState != 1) {
-    return res.status(500).send('REST IS NOT READY')
+    return res
+      .status(500)
+      .type('txt')
+      .send('REST IS NOT READY')
   }
 
   rope
@@ -39,7 +50,10 @@ app.get('/query/:method?', (req, res) => {
     .timeout(REST_TIMEOUT)
     .then(data => res.json(data))
     .catch(() =>
-      res.status(408).send(`Couldn't get response in ${REST_TIMEOUT}ms`)
+      res
+        .status(408)
+        .type('txt')
+        .send(`Couldn't get response in ${REST_TIMEOUT}ms`)
     )
 })
 


### PR DESCRIPTION
This GET endpoint allows the same feature set with the equivalent POST endpoint. Since the data is passed inline `args` keyword needs to be filled out for representing the method arguments.

For the following Rope node example which provides `foo`, `foo1` and `foo2` methods where they accept number of arguments foo takes no argument foo1 takes one argument and so on;

```js
Rope = require('@rope/node').Rope

let rope = new Rope(
  'args-test',
  {
    foo: callback => {
      callback(null, 'null')
    },
    foo1: (hell, callback) => {
      callback(null, typeof hell)
    },
    foo2: (hell, yeah, callback) => {
      callback(null, `${typeof hell} and ${typeof yeah}`)
    },
  },
  { url: 'http://0.0.0.0:3210' }
)
```

Calling `foo`:

```
>> GET http://localhost:3435/method/foo
<< null
```

`foo1`

```
>> GET http://localhost:3435/method/foo1?args=1
<< number
```

`foo2`

```
>> GET http://localhost:3435/method/foo2?args[0]=1&args[1]="gokmen"
<< number and string
```

It tries to convert provided arguments to js objects, so this works;

`foo1`

```
>> GET http://localhost:3435/method/foo1?args={"name":"gokmen"}
<< object
```

`foo2`

```
>> GET http://localhost:3435/method/foo2?args[0]={"name":"gokmen"}&args[1]=5
<< object and number
```

passed JSON should be valid, if it fails to convert it, will use it as `string` instead;

`foo1`

```
>> GET http://localhost:3435/method/foo1?args={name:"gokmen"}
<< string
```

since `{name:"gokmen"}` is not a valid JSON.